### PR TITLE
feat: Usar userDataDir temporal para Puppeteer (diagnóstico)

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,35 +32,36 @@ const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
     const executablePath = await puppeteer.executablePath();
     console.log("🚀 Usando Chromium de Puppeteer en:", executablePath);
 
-    // Intentar eliminar el archivo SingletonLock para prevenir errores de perfil en uso
-    const puppeteerSessionPath = path.join(SESSION_PATH, 'session'); // Este es el user-data-dir que Puppeteer usa según los logs
-    const singletonLockPath = path.join(puppeteerSessionPath, 'SingletonLock');
+    // // Intentar eliminar el archivo SingletonLock para prevenir errores de perfil en uso
+    // const puppeteerSessionPath = path.join(SESSION_PATH, 'session'); // Este es el user-data-dir que Puppeteer usa según los logs
+    // const singletonLockPath = path.join(puppeteerSessionPath, 'SingletonLock');
 
-    try {
-      if (fs.existsSync(singletonLockPath)) {
-        fs.unlinkSync(singletonLockPath);
-        console.log(`[INFO] Se eliminó el archivo SingletonLock existente en: ${singletonLockPath}`);
-      }
-    } catch (err) {
-      console.warn(`[WARN] No se pudo eliminar el archivo SingletonLock en ${singletonLockPath}:`, err.message);
-    }
+    // try {
+    //   if (fs.existsSync(singletonLockPath)) {
+    //     fs.unlinkSync(singletonLockPath);
+    //     console.log(`[INFO] Se eliminó el archivo SingletonLock existente en: ${singletonLockPath}`);
+    //   }
+    // } catch (err) {
+    //   console.warn(`[WARN] No se pudo eliminar el archivo SingletonLock en ${singletonLockPath}:`, err.message);
+    // }
 
-    // Adicionalmente, asegúrate de que el directorio base de la sesión de puppeteer exista,
-    // ya que LocalAuth podría esperarlo.
-    try {
-      if (!fs.existsSync(puppeteerSessionPath)) {
-        fs.mkdirSync(puppeteerSessionPath, { recursive: true });
-        console.log(`[INFO] Se creó el directorio para la sesión de Puppeteer en: ${puppeteerSessionPath}`);
-      }
-    } catch (err) {
-      console.warn(`[WARN] No se pudo crear el directorio para la sesión de Puppeteer en ${puppeteerSessionPath}:`, err.message);
-    }
+    // // Adicionalmente, asegúrate de que el directorio base de la sesión de puppeteer exista,
+    // // ya que LocalAuth podría esperarlo.
+    // try {
+    //   if (!fs.existsSync(puppeteerSessionPath)) {
+    //     fs.mkdirSync(puppeteerSessionPath, { recursive: true });
+    //     console.log(`[INFO] Se creó el directorio para la sesión de Puppeteer en: ${puppeteerSessionPath}`);
+    //   }
+    // } catch (err) {
+    //   console.warn(`[WARN] No se pudo crear el directorio para la sesión de Puppeteer en ${puppeteerSessionPath}:`, err.message);
+    // }
 
     const client = new Client({
       authStrategy: new LocalAuth({ dataPath: SESSION_PATH }), // LocalAuth gestiona la sesión de wwebjs
       puppeteer: {
         headless: true,
         executablePath: executablePath,
+        userDataDir: '/tmp/wwebjs_temp_profile', // <--- Línea añadida/modificada
         args: [
           '--no-sandbox',
           '--disable-setuid-sandbox',
@@ -73,7 +74,6 @@ const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
           '--no-default-browser-check',
           '--disable-breakpad', // <--- Nuevo flag añadido
         ],
-        // userDataDir: puppeteerUserDataPath, // Eliminado: LocalAuth gestionará esto
       },
     });
 


### PR DESCRIPTION
Se modifica `index.js` para configurar Puppeteer de modo que utilice un directorio de datos de usuario temporal y efímero ubicado en `/tmp/wwebjs_temp_profile`.

La lógica anterior que intentaba manejar el `SingletonLock` en el directorio persistente ha sido comentada. La estrategia `LocalAuth` sigue configurada para usar su `dataPath` en el volumen persistente para los archivos de sesión de whatsapp-web.js.

Este cambio se realiza con fines de diagnóstico para determinar si los fallos de inicio de Chromium ("The profile appears to be in use" y errores de crashpad) están vinculados al uso del volumen persistente para el `userDataDir` de Puppeteer.

Nota: Con esta configuración, el estado interno de Chromium no persistirá entre reinicios, lo que podría afectar la persistencia completa de la sesión de WhatsApp si hay dependencias.