### PR TITLE
feat: Limpiar SESSION_PATH en cada inicio para diagnóstico

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,39 +29,71 @@ const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
   let readyTimeout; // Declarar readyTimeout aquí para que sea accesible
 
   try {
+    // Limpiar el directorio SESSION_PATH al inicio para asegurar un estado limpio
+    console.log(`[INFO] Verificando y limpiando el directorio de sesión: ${SESSION_PATH}`);
+    try {
+      if (fs.existsSync(SESSION_PATH)) {
+        console.log(`[INFO] El directorio ${SESSION_PATH} existe. Eliminando su contenido...`);
+        // Eliminar todos los archivos y subdirectorios dentro de SESSION_PATH
+        fs.readdirSync(SESSION_PATH).forEach(file => {
+          const filePath = path.join(SESSION_PATH, file);
+          if (fs.lstatSync(filePath).isDirectory()) {
+            fs.rmSync(filePath, { recursive: true, force: true });
+            console.log(`[INFO] Subdirectorio eliminado: ${filePath}`);
+          } else {
+            fs.unlinkSync(filePath);
+            console.log(`[INFO] Archivo eliminado: ${filePath}`);
+          }
+        });
+        console.log(`[INFO] Contenido de ${SESSION_PATH} eliminado.`);
+      } else {
+        console.log(`[INFO] El directorio ${SESSION_PATH} no existe. Creándolo...`);
+        fs.mkdirSync(SESSION_PATH, { recursive: true });
+        console.log(`[INFO] Directorio ${SESSION_PATH} creado.`);
+      }
+      // Asegurarse de que SESSION_PATH exista después de la limpieza (si se eliminó y recreó o solo se creó)
+      if (!fs.existsSync(SESSION_PATH)) {
+        fs.mkdirSync(SESSION_PATH, { recursive: true });
+        console.log(`[INFO] Se re-creó el directorio ${SESSION_PATH} como medida de seguridad.`);
+      }
+    } catch (err) {
+      console.error(`[ERROR] Error al limpiar o crear el directorio ${SESSION_PATH}:`, err);
+      // Decide si quieres salir o continuar si hay un error aquí.
+      // Por ahora, solo se registrará el error.
+    }
+
     const executablePath = await puppeteer.executablePath();
     console.log("🚀 Usando Chromium de Puppeteer en:", executablePath);
 
-    // // Intentar eliminar el archivo SingletonLock para prevenir errores de perfil en uso
-    // const puppeteerSessionPath = path.join(SESSION_PATH, 'session'); // Este es el user-data-dir que Puppeteer usa según los logs
-    // const singletonLockPath = path.join(puppeteerSessionPath, 'SingletonLock');
+    // Intentar eliminar el archivo SingletonLock para prevenir errores de perfil en uso
+    const puppeteerSessionPath = path.join(SESSION_PATH, 'session'); // Este es el user-data-dir que Puppeteer usa según los logs
+    const singletonLockPath = path.join(puppeteerSessionPath, 'SingletonLock');
 
-    // try {
-    //   if (fs.existsSync(singletonLockPath)) {
-    //     fs.unlinkSync(singletonLockPath);
-    //     console.log(`[INFO] Se eliminó el archivo SingletonLock existente en: ${singletonLockPath}`);
-    //   }
-    // } catch (err) {
-    //   console.warn(`[WARN] No se pudo eliminar el archivo SingletonLock en ${singletonLockPath}:`, err.message);
-    // }
+    try {
+      if (fs.existsSync(singletonLockPath)) {
+        fs.unlinkSync(singletonLockPath);
+        console.log(`[INFO] Se eliminó el archivo SingletonLock existente en: ${singletonLockPath}`);
+      }
+    } catch (err) {
+      console.warn(`[WARN] No se pudo eliminar el archivo SingletonLock en ${singletonLockPath}:`, err.message);
+    }
 
-    // // Adicionalmente, asegúrate de que el directorio base de la sesión de puppeteer exista,
-    // // ya que LocalAuth podría esperarlo.
-    // try {
-    //   if (!fs.existsSync(puppeteerSessionPath)) {
-    //     fs.mkdirSync(puppeteerSessionPath, { recursive: true });
-    //     console.log(`[INFO] Se creó el directorio para la sesión de Puppeteer en: ${puppeteerSessionPath}`);
-    //   }
-    // } catch (err) {
-    //   console.warn(`[WARN] No se pudo crear el directorio para la sesión de Puppeteer en ${puppeteerSessionPath}:`, err.message);
-    // }
+    // Adicionalmente, asegúrate de que el directorio base de la sesión de puppeteer exista,
+    // ya que LocalAuth podría esperarlo.
+    try {
+      if (!fs.existsSync(puppeteerSessionPath)) {
+        fs.mkdirSync(puppeteerSessionPath, { recursive: true });
+        console.log(`[INFO] Se creó el directorio para la sesión de Puppeteer en: ${puppeteerSessionPath}`);
+      }
+    } catch (err) {
+      console.warn(`[WARN] No se pudo crear el directorio para la sesión de Puppeteer en ${puppeteerSessionPath}:`, err.message);
+    }
 
     const client = new Client({
       authStrategy: new LocalAuth({ dataPath: SESSION_PATH }), // LocalAuth gestiona la sesión de wwebjs
       puppeteer: {
         headless: true,
         executablePath: executablePath,
-        userDataDir: '/tmp/wwebjs_temp_profile', // <--- Línea añadida/modificada
         args: [
           '--no-sandbox',
           '--disable-setuid-sandbox',


### PR DESCRIPTION
Se modifica `index.js` para realizar una limpieza recursiva del contenido del directorio `SESSION_PATH` (utilizado como `dataPath` por `LocalAuth`) cada vez que la aplicación se inicia. Esta limpieza ocurre antes de la inicialización de `LocalAuth` y Puppeteer.

Además, he revertido la configuración de `userDataDir` de Puppeteer a la gestionada por defecto por `LocalAuth` y he restaurado la lógica de eliminación de `SingletonLock`.

Este cambio es un intento de diagnóstico para resolver los errores persistentes "The profile appears to be in use" y los problemas relacionados con `crashpad`. Al asegurar un directorio de sesión completamente limpio, espero eliminar cualquier estado corrupto o bloqueo residual que pudiera causar estos fallos.

Anticipo que esta configuración requerirá que escanees el código QR de WhatsApp en cada reinicio o despliegue de la aplicación.