### PR TITLE
Fix browser start issues by ensuring session volume permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,15 +51,19 @@ RUN addgroup --system nodejs && adduser --system --ingroup nodejs nodeuser
 # Crea directorios necesarios y asigna permisos
 RUN mkdir -p /app/session && chown -R nodeuser:nodejs /app
 
-# Cambia al usuario no root
-USER nodeuser
-
-# Copia el resto del proyecto
+# Copia el resto del proyecto con permisos para nodeuser
 COPY --chown=nodeuser:nodejs . .
+
+# Copia script de inicio
+COPY start.sh /start.sh
+RUN chmod +x /start.sh
+
+# Ejecuta como root para poder ajustar permisos de volumen en tiempo de ejecución
+USER root
 
 # Expone el puerto que usa tu app (aunque WhatsApp no necesita puerto HTTP)
 EXPOSE 3000
 
 # Comando principal
-CMD ["node", "index.js"]
+CMD ["/start.sh"]
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Este proyecto tiene:
 
 ### Uso con Docker/Fly.io
 
-Para desplegar el bot en un contenedor (por ejemplo Fly.io) se utiliza el archivo `start.sh`, que ajusta los permisos del volumen de sesión antes de iniciar `node index.js`.
+Para desplegar el bot en un contenedor (por ejemplo Fly.io) se utiliza el archivo `start.sh`. Este script crea el directorio de sesión si no existe, ajusta sus permisos y luego inicia `node index.js`.
 
 1. `docker build -t asistente-whatsapp .`
 2. `docker run -e OPENAI_API_KEY=tu_clave -p 3000:3000 asistente-whatsapp`

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Este proyecto tiene:
 
 1. Ejecutá `npm install`
 2. Configurá tu variable de entorno `OPENAI_API_KEY` (puedes usar Fly.io secrets o un archivo `.env`)
-3. Corré `node index.js` para iniciar el bot
+3. Corré `node index.js` para probarlo localmente
+
+### Uso con Docker/Fly.io
+
+Para desplegar el bot en un contenedor (por ejemplo Fly.io) se utiliza el archivo `start.sh`, que ajusta los permisos del volumen de sesión antes de iniciar `node index.js`.
+
+1. `docker build -t asistente-whatsapp .`
+2. `docker run -e OPENAI_API_KEY=tu_clave -p 3000:3000 asistente-whatsapp`
 
 El bot mantiene la sesión de WhatsApp usando volúmenes persistentes y responde usando GPT.

--- a/index.js
+++ b/index.js
@@ -104,7 +104,8 @@ const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
           '--disable-features=ProcessSingleton',
           '--no-first-run',
           '--no-default-browser-check',
-          '--disable-breakpad', // <--- Nuevo flag añadido
+          '--disable-breakpad',
+          '--disable-crash-reporter',
         ],
       },
     });

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+# Ensure the session directory is owned by nodeuser so Chromium can write to it
+if [ -d /app/session ]; then
+  chown -R nodeuser:nodejs /app/session || true
+fi
+exec su -s /bin/sh nodeuser -c "node index.js"

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
-# Ensure the session directory is owned by nodeuser so Chromium can write to it
-if [ -d /app/session ]; then
-  chown -R nodeuser:nodejs /app/session || true
-fi
+# Ensure session directories exist with correct permissions
+mkdir -p /app/session/wwebjs_auth_data/session
+chown -R nodeuser:nodejs /app/session || true
 exec su -s /bin/sh nodeuser -c "node index.js"


### PR DESCRIPTION
## Summary
- add a runtime start script that fixes permissions of the `/app/session` volume
- update Dockerfile to use the start script and run as root so the volume can be adjusted

## Testing
- `npm install`
- `node --check index.js`


------
https://chatgpt.com/codex/tasks/task_e_6855e77a72dc832cb4abd165b724ed33