### PR TITLE
chore: Increase grace_period in fly.toml to 90s

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -30,7 +30,7 @@ primary_region = "eze"
   min_machines_running = 1
 
   [services.http_checks]
-    grace_period = "30s"
+    grace_period = "90s" # Modificado de "30s"
     interval = "15s"
     method = "GET"
     timeout = "5s"


### PR DESCRIPTION
I've modified the `fly.toml` file to extend the HTTP health check `grace_period` from 30 to 90 seconds.

This change is intended to give your application more time to complete its initialization process, especially loading Puppeteer and Chromium, before the Fly.io platform determines its health status. I expect this will help prevent premature restarts if your application is slow to start up.