### PR TITLE
feat: Separar dataPath de LocalAuth y userDataDir de Puppeteer

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,9 @@ const { getWeather, getEfemeride, getCurrentTime } = require("./functions-handle
 const fs = require('fs');
 const path = require('path');
 
-const SESSION_PATH = "./session/wwebjs_auth_data"; // Modificado: Ruta más específica para LocalAuth
+// const SESSION_PATH = "./session/wwebjs_auth_data"; // Comentado o eliminado
+const LOCALAUTH_DATA_PATH = "./session/wwebjs_auth_files";
+const PUPPETEER_USER_DATA_DIR = path.resolve(__dirname, "./session/chromium_profile_data");
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const ASSISTANT_ID = process.env.OPENAI_ASSISTANT_ID;
 
@@ -29,71 +31,72 @@ const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
   let readyTimeout; // Declarar readyTimeout aquí para que sea accesible
 
   try {
-    // Limpiar el directorio SESSION_PATH al inicio para asegurar un estado limpio
-    console.log(`[INFO] Verificando y limpiando el directorio de sesión: ${SESSION_PATH}`);
-    try {
-      if (fs.existsSync(SESSION_PATH)) {
-        console.log(`[INFO] El directorio ${SESSION_PATH} existe. Eliminando su contenido...`);
-        // Eliminar todos los archivos y subdirectorios dentro de SESSION_PATH
-        fs.readdirSync(SESSION_PATH).forEach(file => {
-          const filePath = path.join(SESSION_PATH, file);
-          if (fs.lstatSync(filePath).isDirectory()) {
-            fs.rmSync(filePath, { recursive: true, force: true });
-            console.log(`[INFO] Subdirectorio eliminado: ${filePath}`);
-          } else {
-            fs.unlinkSync(filePath);
-            console.log(`[INFO] Archivo eliminado: ${filePath}`);
-          }
-        });
-        console.log(`[INFO] Contenido de ${SESSION_PATH} eliminado.`);
-      } else {
-        console.log(`[INFO] El directorio ${SESSION_PATH} no existe. Creándolo...`);
-        fs.mkdirSync(SESSION_PATH, { recursive: true });
-        console.log(`[INFO] Directorio ${SESSION_PATH} creado.`);
-      }
-      // Asegurarse de que SESSION_PATH exista después de la limpieza (si se eliminó y recreó o solo se creó)
-      if (!fs.existsSync(SESSION_PATH)) {
-        fs.mkdirSync(SESSION_PATH, { recursive: true });
-        console.log(`[INFO] Se re-creó el directorio ${SESSION_PATH} como medida de seguridad.`);
-      }
-    } catch (err) {
-      console.error(`[ERROR] Error al limpiar o crear el directorio ${SESSION_PATH}:`, err);
-      // Decide si quieres salir o continuar si hay un error aquí.
-      // Por ahora, solo se registrará el error.
-    }
+    // // Limpiar el directorio SESSION_PATH al inicio para asegurar un estado limpio
+    // console.log(`[INFO] Verificando y limpiando el directorio de sesión: ${SESSION_PATH}`);
+    // try {
+    //   if (fs.existsSync(SESSION_PATH)) {
+    //     console.log(`[INFO] El directorio ${SESSION_PATH} existe. Eliminando su contenido...`);
+    //     // Eliminar todos los archivos y subdirectorios dentro de SESSION_PATH
+    //     fs.readdirSync(SESSION_PATH).forEach(file => {
+    //       const filePath = path.join(SESSION_PATH, file);
+    //       if (fs.lstatSync(filePath).isDirectory()) {
+    //         fs.rmSync(filePath, { recursive: true, force: true });
+    //         console.log(`[INFO] Subdirectorio eliminado: ${filePath}`);
+    //       } else {
+    //         fs.unlinkSync(filePath);
+    //         console.log(`[INFO] Archivo eliminado: ${filePath}`);
+    //       }
+    //     });
+    //     console.log(`[INFO] Contenido de ${SESSION_PATH} eliminado.`);
+    //   } else {
+    //     console.log(`[INFO] El directorio ${SESSION_PATH} no existe. Creándolo...`);
+    //     fs.mkdirSync(SESSION_PATH, { recursive: true });
+    //     console.log(`[INFO] Directorio ${SESSION_PATH} creado.`);
+    //   }
+    //   // Asegurarse de que SESSION_PATH exista después de la limpieza (si se eliminó y recreó o solo se creó)
+    //   if (!fs.existsSync(SESSION_PATH)) {
+    //     fs.mkdirSync(SESSION_PATH, { recursive: true });
+    //     console.log(`[INFO] Se re-creó el directorio ${SESSION_PATH} como medida de seguridad.`);
+    //   }
+    // } catch (err) {
+    //   console.error(`[ERROR] Error al limpiar o crear el directorio ${SESSION_PATH}:`, err);
+    //   // Decide si quieres salir o continuar si hay un error aquí.
+    //   // Por ahora, solo se registrará el error.
+    // }
 
     const executablePath = await puppeteer.executablePath();
     console.log("🚀 Usando Chromium de Puppeteer en:", executablePath);
 
-    // Intentar eliminar el archivo SingletonLock para prevenir errores de perfil en uso
-    const puppeteerSessionPath = path.join(SESSION_PATH, 'session'); // Este es el user-data-dir que Puppeteer usa según los logs
-    const singletonLockPath = path.join(puppeteerSessionPath, 'SingletonLock');
+    // // Intentar eliminar el archivo SingletonLock para prevenir errores de perfil en uso
+    // const puppeteerSessionPath = path.join(SESSION_PATH, 'session'); // Este es el user-data-dir que Puppeteer usa según los logs
+    // const singletonLockPath = path.join(puppeteerSessionPath, 'SingletonLock');
 
-    try {
-      if (fs.existsSync(singletonLockPath)) {
-        fs.unlinkSync(singletonLockPath);
-        console.log(`[INFO] Se eliminó el archivo SingletonLock existente en: ${singletonLockPath}`);
-      }
-    } catch (err) {
-      console.warn(`[WARN] No se pudo eliminar el archivo SingletonLock en ${singletonLockPath}:`, err.message);
-    }
+    // try {
+    //   if (fs.existsSync(singletonLockPath)) {
+    //     fs.unlinkSync(singletonLockPath);
+    //     console.log(`[INFO] Se eliminó el archivo SingletonLock existente en: ${singletonLockPath}`);
+    //   }
+    // } catch (err) {
+    //   console.warn(`[WARN] No se pudo eliminar el archivo SingletonLock en ${singletonLockPath}:`, err.message);
+    // }
 
-    // Adicionalmente, asegúrate de que el directorio base de la sesión de puppeteer exista,
-    // ya que LocalAuth podría esperarlo.
-    try {
-      if (!fs.existsSync(puppeteerSessionPath)) {
-        fs.mkdirSync(puppeteerSessionPath, { recursive: true });
-        console.log(`[INFO] Se creó el directorio para la sesión de Puppeteer en: ${puppeteerSessionPath}`);
-      }
-    } catch (err) {
-      console.warn(`[WARN] No se pudo crear el directorio para la sesión de Puppeteer en ${puppeteerSessionPath}:`, err.message);
-    }
+    // // Adicionalmente, asegúrate de que el directorio base de la sesión de puppeteer exista,
+    // // ya que LocalAuth podría esperarlo.
+    // try {
+    //   if (!fs.existsSync(puppeteerSessionPath)) {
+    //     fs.mkdirSync(puppeteerSessionPath, { recursive: true });
+    //     console.log(`[INFO] Se creó el directorio para la sesión de Puppeteer en: ${puppeteerSessionPath}`);
+    //   }
+    // } catch (err) {
+    //   console.warn(`[WARN] No se pudo crear el directorio para la sesión de Puppeteer en ${puppeteerSessionPath}:`, err.message);
+    // }
 
     const client = new Client({
-      authStrategy: new LocalAuth({ dataPath: SESSION_PATH }), // LocalAuth gestiona la sesión de wwebjs
+      authStrategy: new LocalAuth({ dataPath: LOCALAUTH_DATA_PATH }), // Usar la nueva ruta para LocalAuth
       puppeteer: {
         headless: true,
         executablePath: executablePath,
+        userDataDir: PUPPETEER_USER_DATA_DIR, // Usar la nueva ruta explícita para Puppeteer
         args: [
           '--no-sandbox',
           '--disable-setuid-sandbox',


### PR DESCRIPTION
He modificado `index.js` para utilizar rutas distintas dentro del volumen persistente para los archivos de `LocalAuth` y el perfil de usuario de Chromium (Puppeteer):
- `LocalAuth` usará `dataPath: "./session/wwebjs_auth_files"`.
- Puppeteer usará `userDataDir: "./session/chromium_profile_data"`.

Además, he comentado temporalmente la lógica de limpieza de directorio y de manejo de `SingletonLock` para aislar el efecto de este cambio de rutas.

Este cambio se realiza con fines de diagnóstico para determinar si la estructura de directorios anterior o la forma en que `LocalAuth` gestionaba el `userDataDir` de Puppeteer contribuían al error "The profile appears to be in use" en el entorno de Fly.io.