### PR TITLE
fix: Estandarizar LocalAuth y refinar manejo de SingletonLock

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,7 @@ const { getWeather, getEfemeride, getCurrentTime } = require("./functions-handle
 const fs = require('fs');
 const path = require('path');
 
-// const SESSION_PATH = "./session/wwebjs_auth_data"; // Comentado o eliminado
-const LOCALAUTH_DATA_PATH = "./session/wwebjs_auth_files";
-const PUPPETEER_USER_DATA_DIR = path.resolve(__dirname, "./session/chromium_profile_data");
+const SESSION_DATA_PATH = "./session/wwebjs_auth_data";
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const ASSISTANT_ID = process.env.OPENAI_ASSISTANT_ID;
 
@@ -31,72 +29,34 @@ const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
   let readyTimeout; // Declarar readyTimeout aquí para que sea accesible
 
   try {
-    // // Limpiar el directorio SESSION_PATH al inicio para asegurar un estado limpio
-    // console.log(`[INFO] Verificando y limpiando el directorio de sesión: ${SESSION_PATH}`);
-    // try {
-    //   if (fs.existsSync(SESSION_PATH)) {
-    //     console.log(`[INFO] El directorio ${SESSION_PATH} existe. Eliminando su contenido...`);
-    //     // Eliminar todos los archivos y subdirectorios dentro de SESSION_PATH
-    //     fs.readdirSync(SESSION_PATH).forEach(file => {
-    //       const filePath = path.join(SESSION_PATH, file);
-    //       if (fs.lstatSync(filePath).isDirectory()) {
-    //         fs.rmSync(filePath, { recursive: true, force: true });
-    //         console.log(`[INFO] Subdirectorio eliminado: ${filePath}`);
-    //       } else {
-    //         fs.unlinkSync(filePath);
-    //         console.log(`[INFO] Archivo eliminado: ${filePath}`);
-    //       }
-    //     });
-    //     console.log(`[INFO] Contenido de ${SESSION_PATH} eliminado.`);
-    //   } else {
-    //     console.log(`[INFO] El directorio ${SESSION_PATH} no existe. Creándolo...`);
-    //     fs.mkdirSync(SESSION_PATH, { recursive: true });
-    //     console.log(`[INFO] Directorio ${SESSION_PATH} creado.`);
-    //   }
-    //   // Asegurarse de que SESSION_PATH exista después de la limpieza (si se eliminó y recreó o solo se creó)
-    //   if (!fs.existsSync(SESSION_PATH)) {
-    //     fs.mkdirSync(SESSION_PATH, { recursive: true });
-    //     console.log(`[INFO] Se re-creó el directorio ${SESSION_PATH} como medida de seguridad.`);
-    //   }
-    // } catch (err) {
-    //   console.error(`[ERROR] Error al limpiar o crear el directorio ${SESSION_PATH}:`, err);
-    //   // Decide si quieres salir o continuar si hay un error aquí.
-    //   // Por ahora, solo se registrará el error.
-    // }
-
     const executablePath = await puppeteer.executablePath();
     console.log("🚀 Usando Chromium de Puppeteer en:", executablePath);
 
-    // // Intentar eliminar el archivo SingletonLock para prevenir errores de perfil en uso
-    // const puppeteerSessionPath = path.join(SESSION_PATH, 'session'); // Este es el user-data-dir que Puppeteer usa según los logs
-    // const singletonLockPath = path.join(puppeteerSessionPath, 'SingletonLock');
+    // Intentar eliminar el archivo SingletonLock para prevenir errores de perfil en uso
+    const puppeteerUserDataPath = path.join(SESSION_DATA_PATH, 'session');
+    const singletonLockPath = path.join(puppeteerUserDataPath, 'SingletonLock');
 
-    // try {
-    //   if (fs.existsSync(singletonLockPath)) {
-    //     fs.unlinkSync(singletonLockPath);
-    //     console.log(`[INFO] Se eliminó el archivo SingletonLock existente en: ${singletonLockPath}`);
-    //   }
-    // } catch (err) {
-    //   console.warn(`[WARN] No se pudo eliminar el archivo SingletonLock en ${singletonLockPath}:`, err.message);
-    // }
+    try {
+      // Asegurar que el directorio base del perfil de Puppeteer exista antes de intentar acceder a SingletonLock
+      if (!fs.existsSync(puppeteerUserDataPath)) {
+        fs.mkdirSync(puppeteerUserDataPath, { recursive: true });
+        console.log(`[INFO] Se creó el directorio para el perfil de Puppeteer en: ${puppeteerUserDataPath} ya que no existía.`);
+      }
 
-    // // Adicionalmente, asegúrate de que el directorio base de la sesión de puppeteer exista,
-    // // ya que LocalAuth podría esperarlo.
-    // try {
-    //   if (!fs.existsSync(puppeteerSessionPath)) {
-    //     fs.mkdirSync(puppeteerSessionPath, { recursive: true });
-    //     console.log(`[INFO] Se creó el directorio para la sesión de Puppeteer en: ${puppeteerSessionPath}`);
-    //   }
-    // } catch (err) {
-    //   console.warn(`[WARN] No se pudo crear el directorio para la sesión de Puppeteer en ${puppeteerSessionPath}:`, err.message);
-    // }
+      if (fs.existsSync(singletonLockPath)) {
+        fs.unlinkSync(singletonLockPath);
+        console.log(`[INFO] Se eliminó el archivo SingletonLock existente en: ${singletonLockPath}`);
+      }
+    } catch (err) {
+      console.warn(`[WARN] No se pudo eliminar el archivo SingletonLock o crear el directorio del perfil en ${singletonLockPath}:`, err.message);
+    }
 
     const client = new Client({
-      authStrategy: new LocalAuth({ dataPath: LOCALAUTH_DATA_PATH }), // Usar la nueva ruta para LocalAuth
+      authStrategy: new LocalAuth({ dataPath: SESSION_DATA_PATH }), // Usar la ruta de sesión principal
       puppeteer: {
         headless: true,
         executablePath: executablePath,
-        userDataDir: PUPPETEER_USER_DATA_DIR, // Usar la nueva ruta explícita para Puppeteer
+        // No especificar userDataDir aquí, dejar que LocalAuth lo maneje
         args: [
           '--no-sandbox',
           '--disable-setuid-sandbox',


### PR DESCRIPTION
Se revierte `index.js` a una configuración más estándar para `whatsapp-web.js` utilizando `LocalAuth`:
- Se define un único `SESSION_DATA_PATH` para `LocalAuth.dataPath`.
- Se permite que `LocalAuth` gestione implícitamente la ruta del `userDataDir` de Puppeteer (esperado en `<SESSION_DATA_PATH>/session/`).
- Se elimina la limpieza recursiva de `SESSION_DATA_PATH` del intento anterior.

Se mantiene y refina la lógica para eliminar el archivo `SingletonLock` específicamente de la ruta `<SESSION_DATA_PATH>/session/SingletonLock` antes de la inicialización del cliente. También se asegura que el directorio `<SESSION_DATA_PATH>/session/` exista.

Este enfoque busca resolver el error "The profile appears to be in use" minimizando las modificaciones sobre el comportamiento por defecto de `LocalAuth`, pero atacando directamente el problema del `SingletonLock`.