### PR TITLE
Improve startup script path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,15 +51,18 @@ RUN addgroup --system nodejs && adduser --system --ingroup nodejs nodeuser
 # Crea directorios necesarios y asigna permisos
 RUN mkdir -p /app/session && chown -R nodeuser:nodejs /app
 
-# Cambia al usuario no root
-USER nodeuser
-
-# Copia el resto del proyecto
+# Copia el resto del proyecto con permisos para nodeuser
 COPY --chown=nodeuser:nodejs . .
+
+# Asegura que el script de inicio sea ejecutable
+RUN chmod +x start.sh
+
+# Ejecuta como root para poder ajustar permisos de volumen en tiempo de ejecución
+USER root
 
 # Expone el puerto que usa tu app (aunque WhatsApp no necesita puerto HTTP)
 EXPOSE 3000
 
 # Comando principal
-CMD ["node", "index.js"]
+CMD ["/app/start.sh"]
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Este proyecto tiene:
 
 1. Ejecutá `npm install`
 2. Configurá tu variable de entorno `OPENAI_API_KEY` (puedes usar Fly.io secrets o un archivo `.env`)
-3. Corré `node index.js` para iniciar el bot
+3. Corré `node index.js` para probarlo localmente
+
+### Uso con Docker/Fly.io
+
+Para desplegar el bot en un contenedor (por ejemplo Fly.io) se utiliza el archivo `start.sh`. Este script prepara la carpeta de sesión (crea el directorio, corrige los permisos y elimina archivos de bloqueo que puedan quedar de sesiones previas) antes de iniciar `node index.js`. El contenedor ejecuta automáticamente `/app/start.sh`, por lo que no es necesario invocarlo manualmente en Windows.
+
+1. `docker build -t asistente-whatsapp .`
+2. `docker run -e OPENAI_API_KEY=tu_clave -p 3000:3000 asistente-whatsapp`
 
 El bot mantiene la sesión de WhatsApp usando volúmenes persistentes y responde usando GPT.

--- a/fly.toml
+++ b/fly.toml
@@ -19,7 +19,7 @@ primary_region = "eze"
   cpus = 2
 
 [processes]
-  app = "node index.js"
+  app = "/app/start.sh"
 
 [[services]]
   internal_port = 3000

--- a/index.js
+++ b/index.js
@@ -104,7 +104,8 @@ const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
           '--disable-features=ProcessSingleton',
           '--no-first-run',
           '--no-default-browser-check',
-          '--disable-breakpad', // <--- Nuevo flag añadido
+          '--disable-breakpad',
+          '--disable-crash-reporter',
         ],
       },
     });

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+# Ensure session directories exist with correct permissions
+SESSION_DIR=/app/session/wwebjs_auth_data/session
+mkdir -p "$SESSION_DIR"
+# Fix permissions in case the volume was mounted with root ownership
+chown -R nodeuser:nodejs /app/session || true
+# Remove Chromium lock files that may remain from a crashed session
+rm -f "$SESSION_DIR/SingletonLock" "$SESSION_DIR/SingletonCookie"
+exec su -s /bin/sh nodeuser -c "node index.js"


### PR DESCRIPTION
## Summary
- use absolute path in fly app process
- launch start script via `/app/start.sh`

## Testing
- `npm install`
- `node --check index.js`


------
https://chatgpt.com/codex/tasks/task_e_6855e77a72dc832cb4abd165b724ed33