### PR TITLE
Improve env setup documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=tu_clave_openai
+OPENAI_ASSISTANT_ID=tu_asistente_id
+OPENWEATHER_KEY=tu_clave_openweather

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Este proyecto tiene:
 
 1. Ejecutá `npm install`
 
-2. Configurá tus variables de entorno `OPENAI_API_KEY` y `OPENAI_ASSISTANT_ID` (puedes usar Fly.io secrets o un archivo `.env`)
+2. Configurá las variables de entorno `OPENAI_API_KEY`, `OPENAI_ASSISTANT_ID` y `OPENWEATHER_KEY`. Podés copiarlas desde el archivo `.env.example` y completarlas o definirlas como secretos en Fly.io.
 
 3. Corré `node index.js` para probarlo localmente
 

--- a/start.sh
+++ b/start.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 set -e
 
-# Load environment variables from .env if provided
+# Robustecemos la lectura de variables desde /app/.env si existe
 if [ -f /app/.env ]; then
-  # Export variables while ignoring comments and blank lines
-  export $(grep -v '^#' /app/.env | xargs) || true
+  set -o allexport
+  . /app/.env
+  set +o allexport
 fi
 
 # Ensure session directories exist with correct permissions


### PR DESCRIPTION
## Summary
- document environment variables needed via README and `.env.example`
- clarify env loading in `start.sh`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_685f5e3c041c832ca42aabe06b2c5ce6