### PR TITLE
Restore date and weather functions

### DIFF
--- a/functions-handler.js
+++ b/functions-handler.js
@@ -1,5 +1,73 @@
-// functions-handler.js
-const { procesarConAssistant } = require('./index'); // o al archivo donde realmente esté
+// functions-handler.js - Funciones auxiliares para clima y efemérides
+const axios = require('axios');
+const { procesarConAssistant, obtenerOCrearThread } = require('./index');
+const efemerides = require('./efemerides.json');
+
+function getCurrentDate() {
+  const now = new Date();
+  const day = now.getDate().toString().padStart(2, '0');
+  const month = (now.getMonth() + 1).toString().padStart(2, '0');
+  return `${day}-${month}`;
+}
+
+function getCurrentTime() {
+  const now = new Date();
+  const optionsDate = {
+    timeZone: 'America/Argentina/Mendoza',
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric'
+  };
+  const fechaFormateada = now.toLocaleDateString('es-AR', optionsDate);
+
+  const optionsTime = {
+    timeZone: 'America/Argentina/Mendoza',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false
+  };
+  const horaFormateada = now.toLocaleTimeString('es-AR', optionsTime);
+
+  return `🕒 Son las ${horaFormateada} del ${fechaFormateada}.\n\n🤖 Asistente IA\nMunicipalidad de General San Martín.`;
+}
+
+function getEfemeride() {
+  const today = getCurrentDate();
+  const evento = efemerides[today];
+  if (evento) {
+    return `📅 ${evento}\n\n🤖 Asistente IA\nMunicipalidad de General San Martín.`;
+  } else {
+    return `📅 Hoy no hay efemérides destacadas registradas.\n\n🤖 Asistente IA\nMunicipalidad de General San Martín.`;
+  }
+}
+
+async function getWeather() {
+  const apiKey = process.env.OPENWEATHER_API_KEY;
+  const lat = -33.0819;
+  const lon = -68.4692;
+
+  try {
+    const response = await axios.get('https://api.openweathermap.org/data/2.5/weather', {
+      params: {
+        lat,
+        lon,
+        appid: apiKey,
+        units: 'metric',
+        lang: 'es'
+      }
+    });
+
+    const data = response.data;
+    const temp = data.main.temp;
+    const desc = data.weather[0].description;
+
+    return `🌤️ En San Martín (Mendoza), la temperatura actual es de ${temp}°C, con ${desc}.\n\n🤖 Asistente IA\nMunicipalidad de General San Martín.`;
+
+  } catch (error) {
+    console.error('❌ Error al obtener el clima:', error.response?.data || error.message);
+    return `⚠️ No pude obtener el clima actual. Verificá tu clave o conexión.\n\n🤖 Asistente IA\nMunicipalidad de General San Martín.`;
+  }
+}
 
 async function sendToAssistant(userId, text) {
   try {
@@ -7,13 +75,17 @@ async function sendToAssistant(userId, text) {
       from: userId,
       body: text
     };
-    // Llamamos la lógica ya existente
     const respuesta = await procesarConAssistant(message, await obtenerOCrearThread(userId));
     return respuesta;
   } catch (error) {
-    console.error("❌ [ERROR-sendToAssistant]", error);
-    return "❌ Ocurrió un error al procesar tu mensaje. Por favor, intenta nuevamente.";
+    console.error('❌ [ERROR-sendToAssistant]', error);
+    return '❌ Ocurrió un error al procesar tu mensaje. Por favor, intenta nuevamente.';
   }
 }
 
-module.exports = { sendToAssistant };
+module.exports = {
+  getEfemeride,
+  getWeather,
+  getCurrentTime,
+  sendToAssistant
+};


### PR DESCRIPTION
## Summary
- bring back helpers for efemerides, weather and current time that were accidentally removed
- keep `sendToAssistant` for Telegram

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68719453aa08832c975401163af9fd80