### PR TITLE
Restore message_create handler for incoming messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -969,11 +969,15 @@ async function manejarMensajeEntrante(message) {
 }
 
 client.on("message_create", async (message) => {
-  if (message.fromMe) {
-    return;
-  }
+  try {
+    if (message.fromMe) {
+      return;
+    }
 
-  await manejarMensajeEntrante(message);
+    await manejarMensajeEntrante(message);
+  } catch (error) {
+    console.error("❌ [ERROR-MESSAGE-CREATE]", error);
+  }
 });
 
 // ----------------------------------------------------

--- a/index.js
+++ b/index.js
@@ -955,9 +955,9 @@ client.on("disconnected", (reason) => {
   console.log("🔌 [DISCONNECT] Cliente desconectado:", reason);
 });
 
-client.on("message", async (message) => {
+async function manejarMensajeEntrante(message) {
   try {
-    // Verificar si el mensaje tiene audio
+    // Verificar si el mensaje contiene un audio (nota de voz)
     if (message.hasMedia && message.type === 'ptt') {
       await procesarAudio(message);
     } else {
@@ -966,6 +966,14 @@ client.on("message", async (message) => {
   } catch (error) {
     console.error("❌ [ERROR-MESSAGE-HANDLER]", error);
   }
+}
+
+client.on("message_create", async (message) => {
+  if (message.fromMe) {
+    return;
+  }
+
+  await manejarMensajeEntrante(message);
 });
 
 // ----------------------------------------------------


### PR DESCRIPTION
## Summary
- refactor the WhatsApp message handler into a reusable helper
- listen to the `message_create` event and ignore `fromMe` messages so inbound chats are processed again

## Testing
- OPENAI_API_KEY=dummy OPENAI_ASSISTANT_ID=dummy OPENWEATHER_API_KEY=dummy node index.js *(fails: missing Chromium shared libraries in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb44b3faf0832da5356418e3975a9e